### PR TITLE
link GitHub in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,18 @@
 {
   "name": "gatsby-plugin-material-ui",
   "version": "1.2.3",
-  "description": "Gatsby plugin for Material UI with built-in server-side rendering support",
+  "description": "Gatsby plugin for Material-UI with built-in server-side rendering support",
   "license": "MIT",
   "author": "hello@webappsolutions.de",
-  "repository": "hupe1980/gatsby-plugin-material-ui",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hupe1980/gatsby-plugin-material-ui"
+  },
   "keywords": [
     "react",
     "gatsby",
     "gatsby-plugin",
-    "material ui"
+    "material-ui"
   ],
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
It seems the Algolia search struggle to find the GitHub repository:
https://www.gatsbyjs.org/packages/gatsby-plugin-material-ui/?=material-ui
This should help. Also, I'm using the official library name: Material-UI.