### PR TITLE
Avoid transitive dependency

### DIFF
--- a/gatsby-plugin-material-ui/package.json
+++ b/gatsby-plugin-material-ui/package.json
@@ -28,6 +28,7 @@
     "prepare": "cross-env NODE_ENV=production npm run build"
   },
   "dependencies": {
+    "@emotion/cache": "^11.4.0",
     "@emotion/server": "^11.4.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
We import from this package but we don't declare it as a dependency.